### PR TITLE
Turn on warnings, fix warnings

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -128,6 +128,10 @@ else()
         ${TEST_SOURCES}
     )
 
+    target_compile_options(tests PRIVATE
+        -Wall -Wextra -Wpedantic -Werror
+    )
+
     target_link_libraries(tests
         PRIVATE Eigen3::Eigen
         PRIVATE Catch2::Catch2WithMain

--- a/src/lennardjonesium/engine/integrator.cpp
+++ b/src/lennardjonesium/engine/integrator.cpp
@@ -35,9 +35,9 @@ namespace engine
         const BoundaryCondition& boundary_condition,
         const ForceCalculation& force_calculation
     )
-        : timestep_(timestep),
-          force_calculation_(force_calculation),
-          boundary_condition_(boundary_condition)
+        : timestep_{timestep},
+          boundary_condition_{boundary_condition},
+          force_calculation_{force_calculation}
     {}
 
     // Delegate to the above constructor with null force calculation and boundary condition
@@ -53,7 +53,7 @@ namespace engine
         using S = physics::SystemState;
         return [this, steps](S& s) -> S&
             {
-                for (int i : std::views::iota(0, steps)) {s | *this;}
+                for ([[maybe_unused]] int i : std::views::iota(0, steps)) {s | *this;}
                 return s;
             };
     }

--- a/src/lennardjonesium/engine/integrator.hpp
+++ b/src/lennardjonesium/engine/integrator.hpp
@@ -65,7 +65,7 @@ namespace engine
             // The time step by which we will increment (assumed fixed)
             const double timestep_;
 
-            //A state operator that imposes the boundary condition
+            // A state operator that imposes the boundary condition
             const BoundaryCondition& boundary_condition_;
 
             // A state operator that computes the forces, potential energy, and virial

--- a/src/lennardjonesium/engine/particle_pair_filter.cpp
+++ b/src/lennardjonesium/engine/particle_pair_filter.cpp
@@ -36,9 +36,9 @@ namespace engine
          * separation vector would be in the opposite direction.
          */
         return (
-            (a.first == b.first) && (a.second == b.second) && (a.separation.isApprox(b.separation))
+            (a.first == b.first && a.second == b.second && a.separation.isApprox(b.separation))
             or
-            (a.first == b.second) && (a.second == b.first) && (a.separation.isApprox(-b.separation))
+            (a.first == b.second && a.second == b.first && a.separation.isApprox(-b.separation))
         );
     }
 
@@ -53,10 +53,10 @@ namespace engine
          * itself, and this needs special treatment that is beyond the scope of this project.)
          */
 
-        assert((
-            "Simulation box size is less than the cutoff distance",
-            (bounding_box.array().head<3>() >= cutoff_distance).all()
-        ));
+        assert(
+            (bounding_box.array().head<3>() >= cutoff_distance).all() &&
+            "Simulation box size is less than the cutoff distance"
+        );
     }
 } // namespace engine
 

--- a/src/lennardjonesium/physics/system_state.cpp
+++ b/src/lennardjonesium/physics/system_state.cpp
@@ -24,7 +24,7 @@
 
 namespace physics
 {
-    SystemState::SystemState(int particle_count) : potential_energy{0}, virial{0}
+    SystemState::SystemState(int particle_count)
     {
         // Create initial state with all quantities set to zero
 

--- a/src/lennardjonesium/physics/system_state.hpp
+++ b/src/lennardjonesium/physics/system_state.hpp
@@ -74,8 +74,8 @@ namespace physics
 
         // Dynamic quantities (arising from the interactions between particles)
         Eigen::Matrix4Xd forces;           // Force or acceleration, since mass is normalized to 1
-        double potential_energy;    // Potential energy from particle interactions
-        double virial;              // Virial from pairwise forces
+        double potential_energy{0.0};      // Potential energy from particle interactions
+        double virial{0.0};                // Virial from pairwise forces
 
         // Construct a SystemState with a given particle count
         explicit SystemState(int particle_count = 0);

--- a/tests/lennardjonesium/tools/test_cell_list_array.cpp
+++ b/tests/lennardjonesium/tools/test_cell_list_array.cpp
@@ -47,7 +47,7 @@ SCENARIO("Using the cells() generator on a 3x3x3 array")
     {
         int count{0};
 
-        for (const auto& cell : cell_list_array.cells()) {
+        for ([[maybe_unused]] const auto& cell : cell_list_array.cells()) {
             count++;
         }
 


### PR DESCRIPTION
Apparently we were running without -Wall -Wextra -Wpedantic -Werror.
Turned these compiler flags on and fixed all of the resulting warnings.