### PR TITLE
Add cubic_lattice

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -25,6 +25,8 @@ set(SOURCES
     src/lennardjonesium/tools/bounding_box.cpp
     src/lennardjonesium/tools/cell_list_array.hpp
     src/lennardjonesium/tools/cell_list_array.cpp
+    src/lennardjonesium/tools/cubic_lattice.hpp
+    src/lennardjonesium/tools/cubic_lattice.cpp
 
     src/lennardjonesium/physics/system_state.hpp
     src/lennardjonesium/physics/system_state.cpp

--- a/src/lennardjonesium/abstract/overview.hpp
+++ b/src/lennardjonesium/abstract/overview.hpp
@@ -141,6 +141,22 @@ namespace tools
             // Generator to traverse adjacent pairs of cells (including periodic wrap around)
             std::generator<CellListPair> adjacent_pairs() const;
     };
+
+    class CubicLattice
+    {
+        /**
+         * CubicLattice provides the coordinates of points in a cubic lattice, at the requested
+         * density.  It also computes the BoundingBox of the occupied volume.  There will be
+         * derived classes which implement simple, body-centered, and face-centered cubic lattices.
+         */
+
+        public:
+            CubicLattice(int particle_count, double density);
+
+            virtual std::generator<Eigen::Vector4d> operator() () = 0;
+
+            BoundingBox bounding_box();
+    };
 } // namespace tools
 
 namespace physics

--- a/src/lennardjonesium/engine/initial_condition.cpp
+++ b/src/lennardjonesium/engine/initial_condition.cpp
@@ -31,8 +31,6 @@
 #include <lennardjonesium/physics/system_state.hpp>
 #include <lennardjonesium/engine/initial_condition.hpp>
 
-using random_number_generator = std::mt19937;
-
 // We use a face-centered cubic lattice which has 4 sites per cell, at the following locations
 constexpr int lattice_sites_per_cell{4};
 constexpr std::array<double, 4> lattice_sites[lattice_sites_per_cell] = {
@@ -47,12 +45,6 @@ using vector4d_view = Eigen::Map<const Eigen::Vector4d>;
 
 namespace engine
 {
-    InitialCondition::InitialCondition(int particle_count, double density, double temperature)
-        : InitialCondition::InitialCondition(
-            particle_count, density, temperature, random_number_generator::default_seed
-        )
-    {}
-
     InitialCondition::InitialCondition
     (int particle_count, double density, double temperature, std::random_device::result_type seed)
         : InitialCondition::InitialCondition(
@@ -136,7 +128,7 @@ namespace engine
          * Next, we choose the initial velocities from a Maxwell-Boltzmann distribution.  This is
          * just a normal distribution with mean 0 and variance equal to the temperature.
          */
-        random_number_generator gen{p.seed};
+        random_number_engine_type gen{p.seed};
         std::normal_distribution<> maxwell_boltzmann_distribution{0, std::sqrt(p.temperature)};
 
         // The individual velocity components are all independent, so we treat them as a 1d array

--- a/src/lennardjonesium/engine/initial_condition.hpp
+++ b/src/lennardjonesium/engine/initial_condition.hpp
@@ -24,6 +24,7 @@
 #define LJ_INITIAL_CONDITION_HPP
 
 #include <random>
+#include <concepts>
 
 #include <lennardjonesium/tools/bounding_box.hpp>
 #include <lennardjonesium/physics/system_state.hpp>
@@ -49,10 +50,19 @@ namespace engine
          */
 
         public:
-            InitialCondition(int particle_count, double density, double temperature);
+            /**
+             * Would love to make this a template parameter, but it needs a concept that is not
+             * yet defined in the standard library, and I don't feel like defining it myself.
+             */
+            using random_number_engine_type = std::mt19937;
 
-            InitialCondition(int particle_count, double density, double temperature,
-                             std::random_device::result_type seed);
+            // Constructor
+            InitialCondition(
+                int particle_count,
+                double density,
+                double temperature,
+                std::random_device::result_type seed = random_number_engine_type::default_seed
+            );
             
             // These return by value so that the original InitialCondition will not be modified
             tools::BoundingBox bounding_box() {return bounding_box_;}

--- a/src/lennardjonesium/tools/cubic_lattice.cpp
+++ b/src/lennardjonesium/tools/cubic_lattice.cpp
@@ -1,0 +1,73 @@
+/**
+ * cubic_lattice.cpp
+ * 
+ * Copyright (c) 2021-2022 Benjamin E. Niehoff
+ * 
+ * This file is part of Lennard-Jonesium.
+ * 
+ * Lennard-Jonesium is free software: you can redistribute
+ * it and/or modify it under the terms of the GNU General Public
+ * License as published by the Free Software Foundation, either
+ * version 3 of the License, or (at your option) any later version.
+ * 
+ * Lennard-Jonesium is distributed in the hope that it will
+ * be useful, but WITHOUT ANY WARRANTY; without even the implied
+ * warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU General Public License for more details.
+ * 
+ * You should have received a copy of the GNU General Public
+ * License along with Lennard-Jonesium.  If not, see
+ * <https://www.gnu.org/licenses/>.
+ */
+
+#include <cassert>
+#include <cstdlib>
+#include <cmath>
+#include <ranges>
+
+#include <Eigen/Dense>
+
+#include <lennardjonesium/draft_cpp23/generator.hpp>
+#include <lennardjonesium/tools/bounding_box.hpp>
+#include <lennardjonesium/tools/cubic_lattice.hpp>
+
+namespace tools
+{
+    CubicLattice::CubicLattice
+        (int particle_count, double density, CubicLattice::UnitCell unit_cell)
+        : unit_cell_{unit_cell},
+          scale_{std::cbrt(unit_cell.density<double>() / density)},
+          particle_count_{particle_count},
+          cells_per_side_{static_cast<int>(std::ceil(
+              std::cbrt(static_cast<double>(particle_count) / unit_cell.density<double>())
+          ))}
+    {}
+
+    std::generator<Eigen::Vector4d> CubicLattice::operator() ()
+    {
+        for (int index : std::views::iota(0, particle_count_))
+        {
+            /**
+             * To get the coordinates of the current lattice site, we note that the index can be
+             * decomposed in the following way:
+             * 
+             *  index = ((x * cells_per_side_ + y) * cells_per_side_ + z) * unit_cell.density + s
+             * 
+             * where (x, y, z) is the coordinate of the base point of the lattice cell, and then s
+             * gives the index of the specific site within the lattice cell.  We can obtain
+             * (x, y, z, s) by a sequence of quotient-remainder operations.
+             */
+            auto xyz_s = std::div(index, unit_cell_.density<int>());
+            auto xy_z = std::div(xyz_s.quot, cells_per_side_);
+            auto x_y = std::div(xy_z.quot, cells_per_side_);
+
+            // Now we can construct the lattice coordinate
+            Eigen::Vector4i lattice_cell {x_y.quot, x_y.rem, xy_z.rem, 0};
+
+            co_yield (
+                lattice_cell.cast<double>() + unit_cell_.lattice_sites.col(xyz_s.rem)
+            ) * scale_;
+        }
+    }
+} // namespace tools
+

--- a/src/lennardjonesium/tools/cubic_lattice.hpp
+++ b/src/lennardjonesium/tools/cubic_lattice.hpp
@@ -1,0 +1,102 @@
+/**
+ * cubic_lattice.hpp
+ * 
+ * Copyright (c) 2021-2022 Benjamin E. Niehoff
+ * 
+ * This file is part of Lennard-Jonesium.
+ * 
+ * Lennard-Jonesium is free software: you can redistribute
+ * it and/or modify it under the terms of the GNU General Public
+ * License as published by the Free Software Foundation, either
+ * version 3 of the License, or (at your option) any later version.
+ * 
+ * Lennard-Jonesium is distributed in the hope that it will
+ * be useful, but WITHOUT ANY WARRANTY; without even the implied
+ * warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU General Public License for more details.
+ * 
+ * You should have received a copy of the GNU General Public
+ * License along with Lennard-Jonesium.  If not, see
+ * <https://www.gnu.org/licenses/>.
+ */
+
+#ifndef LJ_CUBIC_LATTICE_HPP
+#define LJ_CUBIC_LATTICE_HPP
+
+#include <type_traits>
+
+#include <Eigen/Dense>
+
+#include <lennardjonesium/draft_cpp23/generator.hpp>
+#include <lennardjonesium/tools/bounding_box.hpp>
+
+namespace tools
+{
+    class CubicLattice
+    {
+        /**
+         * CubicLattice provides the coordinates of points in a cubic lattice, at the requested
+         * density.  It also computes the BoundingBox of the occupied volume.  There will be
+         * derived classes which implement simple, body-centered, and face-centered cubic lattices.
+         */
+
+        public:
+            struct UnitCell
+            {
+                /**
+                 * The UnitCell will determine what sort of cubic lattice we are talking about.
+                 * It is determined by an Eigen matrix whose columns are the lattice sites, scaled
+                 * to fit within a standard 1x1x1 cube.
+                 */
+
+                const Eigen::Matrix4Xd lattice_sites;
+
+                /**
+                 * The "density" is just the number of lattice sites in the cell.  We use it as
+                 * either int or double, depending on context.
+                 */
+                template <typename T> requires std::is_arithmetic_v<T>
+                auto density() {return static_cast<T>(lattice_sites.cols());}
+            };
+
+            // The following static methods create the three basic cubic lattices
+            inline static UnitCell Simple() {return UnitCell{
+                Eigen::MatrixX4d{{0.0, 0.0, 0.0, 0.0}}.transpose()
+            };}
+
+            inline static UnitCell BodyCentered() {return UnitCell{
+                Eigen::MatrixX4d{{0.0, 0.0, 0.0, 0.0}, {0.5, 0.5, 0.5, 0.0}}.transpose()
+            };}
+
+            inline static UnitCell FaceCentered() {return UnitCell{
+                Eigen::MatrixX4d{
+                    {0.0, 0.0, 0.0, 0.0},
+                    {0.5, 0.5, 0.0, 0.0},
+                    {0.5, 0.0, 0.5, 0.0},
+                    {0.0, 0.5, 0.5, 0.0}
+                }.transpose()
+            };}
+
+            // The constructor takes a unit cell type to fully specify the cubie lattice
+            CubicLattice(int particle_count, double density, UnitCell unit_cell = FaceCentered());
+
+            /**
+             * The unit cells will be enumerated at coordinates that fit inside the smallest
+             * possible cube.
+             */
+            std::generator<Eigen::Vector4d> operator() ();
+
+            BoundingBox bounding_box()
+                {return BoundingBox(static_cast<double>(cells_per_side_) * scale_);}
+        
+        private:
+            UnitCell unit_cell_;
+            double scale_;
+            int particle_count_;
+            int cells_per_side_;
+            
+    };
+} // namespace tools
+
+
+#endif


### PR DESCRIPTION
The InitialCondition code is kind of ugly and I think the best way to
refactor it is to add a CubicLattice tool that handles the details of
generating the lattice sites.  Then InitialCondition should only need
to be concerned with the physically relevant quantities that are given
in its constructor.

We still need to change InitialCondition to actually use the new
CubicLattice tool, as well as write unit tests.