### PR TITLE
Refactor InitialCondition to use CubicLattice

### DIFF
--- a/src/lennardjonesium/engine/initial_condition.cpp
+++ b/src/lennardjonesium/engine/initial_condition.cpp
@@ -21,121 +21,78 @@
  */
 
 #include <random>
-#include <cmath>
-#include <array>
 #include <ranges>
 
 #include <Eigen/Dense>
 
 #include <lennardjonesium/tools/bounding_box.hpp>
+#include <lennardjonesium/tools/cubic_lattice.hpp>
 #include <lennardjonesium/physics/system_state.hpp>
 #include <lennardjonesium/engine/initial_condition.hpp>
 
-// We use a face-centered cubic lattice which has 4 sites per cell, at the following locations
-constexpr int lattice_sites_per_cell{4};
-constexpr std::array<double, 4> lattice_sites[lattice_sites_per_cell] = {
-    {0.0, 0.0, 0.0, 0.0},
-    {0.5, 0.5, 0.0, 0.0},
-    {0.5, 0.0, 0.5, 0.0},
-    {0.0, 0.5, 0.5, 0.0}
-};
-
-// We will want to treat the above values as Eigen vectors
-using vector4d_view = Eigen::Map<const Eigen::Vector4d>;
-
 namespace engine
 {
-    InitialCondition::InitialCondition
-    (int particle_count, double density, double temperature, std::random_device::result_type seed)
+    InitialCondition::InitialCondition(
+        int particle_count,
+        double density,
+        double temperature,
+        tools::CubicLattice::UnitCell unit_cell,
+        std::random_device::result_type seed
+    )
         : InitialCondition::InitialCondition(
-            InitialCondition::Parameters_{particle_count, density, temperature, seed}
+            particle_count,
+            density,
+            temperature,
+            tools::CubicLattice{particle_count, density, unit_cell},
+            seed
         )
     {}
 
-    InitialCondition::Parameters_::Parameters_
-    (int particle_count, double density, double temperature, std::random_device::result_type seed)
-        : density{density}, temperature{temperature}, seed{seed}
-    {
-        /**
-         * First obtain the number of lattice sites along a single side.  We obtain this by solving
-         * 
-         *      lattice_sites_per_cell * (lattice_size)^3 = particle_count
-         * 
-         * for lattice_size, and rounding up (so that the total number of particles is at least
-         * particle_count).
-         */
-        lattice_size = std::ceil(
-            std::cbrt(
-                static_cast<double>(particle_count) / static_cast<double>(lattice_sites_per_cell)
-            )
-        );
-
-        /**
-         * Next we obtain the cell_size by requiring that
-         * 
-         *      lattice_sites_per_cell / (cell_size)^3 = density
-         * 
-         * and solving this for cell_size.
-         */
-        cell_size = std::cbrt(static_cast<double>(lattice_sites_per_cell) / density);
-    }
-
-    InitialCondition::InitialCondition(InitialCondition::Parameters_ p)
-        : bounding_box_{p.cell_size * static_cast<double>(p.lattice_size)},
-          system_state_{lattice_sites_per_cell * p.lattice_size * p.lattice_size * p.lattice_size},
-          density_{p.density},
-          temperature_{p.temperature},
-          seed_{p.seed}
+    InitialCondition::InitialCondition(
+        int particle_count,
+        double density,
+        double temperature,
+        tools::CubicLattice cubic_lattice,
+        std::random_device::result_type seed
+    )
+        : bounding_box_{cubic_lattice.bounding_box()},
+          system_state_{particle_count},
+          density_{density},
+          temperature_{temperature},
+          seed_{seed}
     {
         /**
          * Now we set the initial positions of all the particles by placing them on the lattice
-         * sites of a face-centered-cubic crystal lattice.
+         * sites determined by the CubicLattice.
+         * 
+         * Unfortunately, std::views::zip does not yet exist, so we need to keep track of an index
+         * manually in order to know which particle should be assigned where.
          */
-        const Eigen::Array4d unit_cell{p.cell_size, p.cell_size, p.cell_size, 1.0};
-
-        /**
-         * We need the indices i, j, k, site_index to construct the various position vectors,
-         * so we are stuck either using 4 nested loops, or a single loop up to the particle_count,
-         * but then decomposing this loop index into (i, j, k, site_index) with a series of modulo
-         * operations.  It is much easier to read with nested loops.
-         */
-        for (int i : std::views::iota(0, p.lattice_size))
+        for (int index = 0; auto position : cubic_lattice())
         {
-            for (int j : std::views::iota(0, p.lattice_size))
-            {
-                for (int k : std::views::iota(0, p.lattice_size))
-                {
-                    for (int site_index : std::views::iota(0, lattice_sites_per_cell))
-                    {
-                        // First compute the index of the particle we will modify
-                        int particle_index = site_index + lattice_sites_per_cell * (
-                            k + p.lattice_size * (j + p.lattice_size * i)
-                        );
-
-                        // Next compute and set the particle's position
-                        Eigen::Vector4i cell_base{i, j, k, 0};
-                        vector4d_view lattice_site_offset{lattice_sites[site_index].data()};
-
-                        system_state_.positions.col(particle_index) = (
-                            (cell_base.cast<double>() + lattice_site_offset).array() * unit_cell
-                        ).matrix();
-                    }
-                }
-            }
+            system_state_.positions.col(index) = position;
+            ++index;
         }
 
         /**
          * Next, we choose the initial velocities from a Maxwell-Boltzmann distribution.  This is
          * just a normal distribution with mean 0 and variance equal to the temperature.
          */
-        random_number_engine_type gen{p.seed};
-        std::normal_distribution<> maxwell_boltzmann_distribution{0, std::sqrt(p.temperature)};
+        random_number_engine_type gen{seed_};
+        std::normal_distribution<> maxwell_boltzmann_distribution{0, std::sqrt(temperature_)};
 
         // The individual velocity components are all independent, so we treat them as a 1d array
         for (auto& velocity_component : system_state_.velocities.reshaped())
         {
             velocity_component = maxwell_boltzmann_distribution(gen);
         }
+
+        /**
+         * TODO: We still need to zero the linear and angular momentum, which will in turn affect
+         * the temperature (since kinetic energy is not invariant under changes of frame).
+         * We can also include a final temperature rescaling step, but temperature rescaling needs
+         * to be defined outside this class, since it will also be used elsewhere.
+         */
     }
 } // namespace engine
 

--- a/src/lennardjonesium/engine/initial_condition.hpp
+++ b/src/lennardjonesium/engine/initial_condition.hpp
@@ -27,6 +27,7 @@
 #include <concepts>
 
 #include <lennardjonesium/tools/bounding_box.hpp>
+#include <lennardjonesium/tools/cubic_lattice.hpp>
 #include <lennardjonesium/physics/system_state.hpp>
 
 namespace engine
@@ -61,6 +62,7 @@ namespace engine
                 int particle_count,
                 double density,
                 double temperature,
+                tools::CubicLattice::UnitCell unit_cell = tools::CubicLattice::FaceCentered(),
                 std::random_device::result_type seed = random_number_engine_type::default_seed
             );
             
@@ -75,34 +77,17 @@ namespace engine
             std::random_device::result_type seed() {return seed_;}
         
         private:
-            struct Parameters_
-            {
-                /**
-                 * The Parameters object is a helper struct to allow us to do some computation on
-                 * the input parameters and repackage them into a type for overload resolution.
-                 * This allows us to pre-compute some necessary information in the initializer list
-                 * before constructing the BoundingBox and the SystemState; in particular, it
-                 * allows both objects to be stack-allocated.
-                 * 
-                 * For the initial particle placement, we will use a face-centered cubic crystal
-                 * structure.  Given the input parameters, we need to calculate how many lattice
-                 * cells (along one dimension) are required, as well as the linear size of each
-                 * lattice cell.
-                 */
-
-                int lattice_size;
-                double cell_size;
-
-                double density;
-                double temperature;
-                std::random_device::result_type seed;
-
-                Parameters_(int particle_count, double density, double temperature,
-                            std::random_device::result_type seed);
-            };
-
-            // Delegate constructor
-            InitialCondition(Parameters_);
+            /**
+             * Delegate constructor requires all arguments, and substitutes complete CubicLattice
+             * for UnitCell
+             */
+            InitialCondition(
+                int particle_count,
+                double density,
+                double temperature,
+                tools::CubicLattice cubic_lattice,
+                std::random_device::result_type seed
+            );
 
             // Data members
             tools::BoundingBox bounding_box_;


### PR DESCRIPTION
The reason for writing CubicLattice was because InitialCondition was
getting unwieldy, and especially the code used to construct it and set
up the initial particle positions was quite convoluted and beginning
to feel like it was taking on too much responsibility.  CubicLattice
allows us to delegate most of that responsibility, so that
InitialCondition construction can be simplified as well as focus mainly
on physically-relevant notions.