### PR TITLE
Add transformations which modify the system state

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -86,6 +86,8 @@ add_library(physics STATIC
     src/lennardjonesium/physics/forces.hpp
     src/lennardjonesium/physics/measurements.hpp
     src/lennardjonesium/physics/measurements.cpp
+    src/lennardjonesium/physics/transformations.hpp
+    src/lennardjonesium/physics/transformations.cpp
 )
 
 add_library(engine STATIC

--- a/src/lennardjonesium/engine/initial_condition.cpp
+++ b/src/lennardjonesium/engine/initial_condition.cpp
@@ -28,6 +28,7 @@
 #include <lennardjonesium/tools/bounding_box.hpp>
 #include <lennardjonesium/tools/cubic_lattice.hpp>
 #include <lennardjonesium/physics/system_state.hpp>
+#include <lennardjonesium/physics/transformations.hpp>
 #include <lennardjonesium/engine/initial_condition.hpp>
 
 namespace engine
@@ -88,11 +89,18 @@ namespace engine
         }
 
         /**
-         * TODO: We still need to zero the linear and angular momentum, which will in turn affect
-         * the temperature (since kinetic energy is not invariant under changes of frame).
-         * We can also include a final temperature rescaling step, but temperature rescaling needs
-         * to be defined outside this class, since it will also be used elsewhere.
+         * We still need to zero the linear and angular momentum, which will in turn affect
+         * the temperature (since kinetic energy is not invariant under changes of frame).  It is
+         * important to do these corrections in the order given, since otherwise they may interfere
+         * with each other.
          */
+
+        system_state_
+            | physics::zero_angular_momentum
+            | physics::zero_momentum
+            | physics::set_temperature(temperature_);
+        
+        // Now the initial state is set up.
     }
 } // namespace engine
 

--- a/src/lennardjonesium/physics/measurements.hpp
+++ b/src/lennardjonesium/physics/measurements.hpp
@@ -60,6 +60,16 @@ namespace physics
         {return total_energy(state, kinetic_energy(state));}
     
     /**
+     * Similarly, the temperature is just proportional to the kinetic energy, so we provide simple
+     * overloads.
+     */
+    inline double temperature(double kinetic_energy)
+        {return (2./3.) * kinetic_energy;}
+
+    inline double temperature(const SystemState& state)
+        {return temperature(kinetic_energy(state));}
+    
+    /**
      * The inertia tensor is given as a 4x4 matrix for alignement reasons.  The upper 3x3 block
      * is the 3-dimensional inertia tensor.  The (i, 4) and (4, j) elements are zero.  The (4, 4)
      * element is equal to 1/2 times the trace of the 3-dimensional inertia tensor, although its

--- a/src/lennardjonesium/physics/transformations.cpp
+++ b/src/lennardjonesium/physics/transformations.cpp
@@ -1,0 +1,107 @@
+/**
+ * transformations.hpp
+ * 
+ * Copyright (c) 2021-2022 Benjamin E. Niehoff
+ * 
+ * This file is part of Lennard-Jonesium.
+ * 
+ * Lennard-Jonesium is free software: you can redistribute
+ * it and/or modify it under the terms of the GNU General Public
+ * License as published by the Free Software Foundation, either
+ * version 3 of the License, or (at your option) any later version.
+ * 
+ * Lennard-Jonesium is distributed in the hope that it will
+ * be useful, but WITHOUT ANY WARRANTY; without even the implied
+ * warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU General Public License for more details.
+ * 
+ * You should have received a copy of the GNU General Public
+ * License along with Lennard-Jonesium.  If not, see
+ * <https://www.gnu.org/licenses/>.
+ */
+
+#include <cmath>
+#include <ranges>
+
+#include <Eigen/Dense>
+
+#include <lennardjonesium/physics/system_state.hpp>
+#include <lennardjonesium/physics/measurements.hpp>
+#include <lennardjonesium/physics/transformations.hpp>
+
+namespace physics
+{
+    SystemState::Operator set_momentum(Eigen::Vector4d momentum)
+    {
+        return [momentum](SystemState& state) -> SystemState&
+        {
+            /**
+             * Take the difference in momenta divided by the total mass to get the velocity delta
+             * which should be added to every velocity in the system
+             */
+
+            state.velocities.colwise() += (
+                (momentum - total_momentum(state)) / static_cast<double>(state.particle_count())
+            );
+
+            return state;
+        };
+    }
+
+    SystemState::Operator set_angular_momentum
+        (Eigen::Vector4d angular_momentum, const Eigen::Ref<const Eigen::Vector4d>& center)
+    {
+        return [angular_momentum, center](SystemState& state) -> SystemState&
+        {
+            /**
+             * To change the angular momentum, we must compute the necessary change in angular
+             * velocity.  This means solving
+             * 
+             *      (L' - L) = (inertia_tensor) * (omega' - omega)
+             * 
+             * for (omega - omega').  We use a full-pivot Householder linear solver from Eigen.
+             */
+
+            auto delta_omega = inertia_tensor(state, center).fullPivHouseholderQr().solve(
+                angular_momentum - total_angular_momentum(state, center)
+            );
+
+            /**
+             * Given the change in angular velocity, we must then apply it to the system velocities
+             * using the formula
+             * 
+             *      (velocity' - velocity) = (omega' - omega) x (position - center)
+             * 
+             * where x is the cross product.  Unfortunately we have to write this loop explicitly,
+             * since Eigen does not provide a colwise() version of cross3().
+             */
+
+            for (int i : std::views::iota(0, state.particle_count()))
+            {
+                state.velocities.col(i) += delta_omega.cross3(state.positions.col(i) - center);
+            }
+
+            return state;
+        };
+    }
+
+    SystemState::Operator set_temperature(double temperature)
+    {
+        return [temperature](SystemState& state) -> SystemState&
+        {
+            /**
+             * To change the temperature of the state, we note that temperature scales quadratically
+             * with velocity
+             * 
+             *      T = (1/3) sum(velocity * velocity)
+             * 
+             * so we can correct the temperature by scaling the velocities by the square root of
+             * the ratio of temperatures.
+             */
+
+            state.velocities *= std::sqrt(temperature / physics::temperature(state));
+
+            return state;
+        };
+    }
+} // namespace physics

--- a/src/lennardjonesium/physics/transformations.hpp
+++ b/src/lennardjonesium/physics/transformations.hpp
@@ -1,0 +1,57 @@
+/**
+ * transformations.hpp
+ * 
+ * Copyright (c) 2021-2022 Benjamin E. Niehoff
+ * 
+ * This file is part of Lennard-Jonesium.
+ * 
+ * Lennard-Jonesium is free software: you can redistribute
+ * it and/or modify it under the terms of the GNU General Public
+ * License as published by the Free Software Foundation, either
+ * version 3 of the License, or (at your option) any later version.
+ * 
+ * Lennard-Jonesium is distributed in the hope that it will
+ * be useful, but WITHOUT ANY WARRANTY; without even the implied
+ * warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU General Public License for more details.
+ * 
+ * You should have received a copy of the GNU General Public
+ * License along with Lennard-Jonesium.  If not, see
+ * <https://www.gnu.org/licenses/>.
+ */
+
+#ifndef LJ_TRANSFORMATIONS_HPP
+#define LJ_TRANSFORMATIONS_HPP
+
+#include <Eigen/Dense>
+
+#include <lennardjonesium/physics/system_state.hpp>
+#include <lennardjonesium/physics/measurements.hpp>
+
+namespace physics
+{
+    /**
+     * Transformations are Operators that change the SystemState in some way, such as scaling the
+     * temperature or adding some amount of momentum.  They are useful mostly when setting up the
+     * simulation, to ensure that the randomly-generated velocities have some desired properties.
+     */
+
+    SystemState::Operator set_momentum(Eigen::Vector4d momentum);
+
+    // NOTE: When setting the angular momentum, it is possible that the linear momentum can change!
+    SystemState::Operator set_angular_momentum(
+        Eigen::Vector4d angular_momentum,
+        const Eigen::Ref<const Eigen::Vector4d>& center = Eigen::Vector4d::Zero()
+    );
+
+    SystemState::Operator set_temperature(double temperature);
+
+    inline SystemState& zero_momentum(SystemState& s)
+        {return s | set_momentum(Eigen::Vector4d::Zero());}
+
+    inline SystemState& zero_angular_momentum(SystemState& s)
+        {return s | set_angular_momentum(Eigen::Vector4d::Zero());}
+} // namespace physics
+
+
+#endif


### PR DESCRIPTION
There are certain operations which are useful to perform at various
times during the course of simulation, such as changing or zeroing-out
the total momentum and angular momentum, and rescaling the temperature.

The functions in transformations.(hpp|cpp) accomplish these tasks.