### PR TITLE
Fix temperature calculation

### DIFF
--- a/src/lennardjonesium/physics/measurements.hpp
+++ b/src/lennardjonesium/physics/measurements.hpp
@@ -23,6 +23,8 @@
 #ifndef LJ_MEASUREMENTS_HPP
 #define LJ_MEASUREMENTS_HPP
 
+#include <cassert>
+
 #include <Eigen/Dense>
 
 #include <lennardjonesium/physics/system_state.hpp>
@@ -60,14 +62,18 @@ namespace physics
         {return total_energy(state, kinetic_energy(state));}
     
     /**
-     * Similarly, the temperature is just proportional to the kinetic energy, so we provide simple
-     * overloads.
+     * Similarly, the temperature is proportional to average the kinetic energy, so we provide
+     * simple overloads.
      */
-    inline double temperature(double kinetic_energy)
-        {return (2./3.) * kinetic_energy;}
+    inline double temperature(const SystemState& state, double kinetic_energy)
+    {
+        assert(state.particle_count() > 0 && "Cannot compute temperature of empty state.");
+        
+        return (2./3.) * kinetic_energy / static_cast<double>(state.particle_count());
+    }
 
     inline double temperature(const SystemState& state)
-        {return temperature(kinetic_energy(state));}
+        {return temperature(state, kinetic_energy(state));}
     
     /**
      * The inertia tensor is given as a 4x4 matrix for alignement reasons.  The upper 3x3 block

--- a/src/lennardjonesium/physics/transformations.cpp
+++ b/src/lennardjonesium/physics/transformations.cpp
@@ -99,7 +99,7 @@ namespace physics
              * To change the temperature of the state, we note that temperature scales quadratically
              * with velocity
              * 
-             *      T = (1/3) sum(velocity * velocity)
+             *      T = (1/3N) sum(velocity * velocity)
              * 
              * so we can correct the temperature by scaling the velocities by the square root of
              * the ratio of temperatures.

--- a/tests/lennardjonesium/physics/test_bulk_properties.cpp
+++ b/tests/lennardjonesium/physics/test_bulk_properties.cpp
@@ -13,7 +13,9 @@
 SCENARIO("Measurements of bulk properties of the system")
 {
     // We set up a state with four particles at the following points
-    physics::SystemState state{4};
+    int particle_count{4};
+
+    physics::SystemState state{particle_count};
 
     state.positions = Eigen::MatrixX4d{
         {0, 0, 0, 0}, {0, 0, 2, 0}, {2, 2, 0, 0}, {2, 2, 2, 0}
@@ -81,7 +83,7 @@ SCENARIO("Measurements of bulk properties of the system")
         }.transpose();
 
         double kinetic_energy{4};
-        double temperature{8./3.};
+        double temperature{8./3. / particle_count};
 
         Eigen::Vector4d total_momentum{0, 0, 0, 0};
 
@@ -123,7 +125,7 @@ SCENARIO("Measurements of bulk properties of the system")
         }.transpose();
 
         double kinetic_energy{4};
-        double temperature{8./3.};
+        double temperature{8./3. / particle_count};
 
         Eigen::Vector4d total_momentum{0, 0, 0, 0};
 
@@ -174,7 +176,9 @@ SCENARIO("Measurements of bulk properties of the system")
 SCENARIO("Transformations of bulk properties of a small system")
 {
     // We set up a state with four particles at the following points
-    physics::SystemState state{4};
+    int particle_count{4};
+
+    physics::SystemState state{particle_count};
 
     state.positions = Eigen::MatrixX4d{
         {0, 0, 0, 0}, {0, 0, 2, 0}, {2, 2, 0, 0}, {2, 2, 2, 0}


### PR DESCRIPTION
Temperature should be computed as (2/3) times the *average* kinetic
energy (per particle), not the *total* kinetic energy.