### PR TITLE
Add simulation_phase.hpp

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -89,9 +89,9 @@ add_library(physics STATIC
     src/lennardjonesium/physics/forces.hpp
     src/lennardjonesium/physics/derived_properties.hpp
     src/lennardjonesium/physics/derived_properties.cpp
+    src/lennardjonesium/physics/measurements.hpp
     src/lennardjonesium/physics/transformations.hpp
     src/lennardjonesium/physics/transformations.cpp
-    src/lennardjonesium/physics/measurements.hpp
 )
 
 add_library(engine STATIC
@@ -105,6 +105,8 @@ add_library(engine STATIC
     src/lennardjonesium/engine/integrator.cpp
     src/lennardjonesium/engine/initial_condition.hpp
     src/lennardjonesium/engine/initial_condition.cpp
+    src/lennardjonesium/engine/simulation_phase.hpp
+    src/lennardjonesium/engine/simulation_phase.cpp
     src/lennardjonesium/engine/equilibrator.hpp
     src/lennardjonesium/engine/equilibrator.cpp
 )
@@ -112,19 +114,16 @@ add_library(engine STATIC
 # Link the various dependencies
 target_link_libraries(abstract
     PRIVATE Eigen3::Eigen
-    PRIVATE fmt::fmt
     PRIVATE draft_cpp23
 )
 
 target_link_libraries(tools
     PRIVATE Eigen3::Eigen
-    PRIVATE fmt::fmt
     PRIVATE draft_cpp23
 )
 
 target_link_libraries(physics
     PRIVATE Eigen3::Eigen
-    PRIVATE fmt::fmt
     PRIVATE tools
 )
 
@@ -171,13 +170,14 @@ else()
         tests/lennardjonesium/engine/test_short_range_force_calculation.cpp
         tests/lennardjonesium/engine/test_velocity_verlet_integrator.cpp
         tests/lennardjonesium/engine/test_initial_condition.cpp
+        tests/lennardjonesium/engine/test_equilibration_phase.cpp
         # tests/lennardjonesium/engine/test_equilibrator.cpp
     )
 
     target_link_libraries(tests
         PRIVATE Eigen3::Eigen
         PRIVATE Catch2::Catch2WithMain
-        PRIVATE fmt::fmt
+        # PRIVATE fmt::fmt
         # PRIVATE Microsoft.GSL::GSL
         # PRIVATE ktl::ktl
         PRIVATE greeter

--- a/src/lennardjonesium/engine/equilibrator.cpp
+++ b/src/lennardjonesium/engine/equilibrator.cpp
@@ -64,7 +64,7 @@ namespace engine
             }
             
             // Check whether an adjustment is needed
-            if (time_step % parameters_.adjustment_interval == 0)
+            if (time_step % parameters_.assessment_interval == 0)
             {
                 double measured_temperature = temperature_samples.statistics().mean;
 

--- a/src/lennardjonesium/engine/equilibrator.hpp
+++ b/src/lennardjonesium/engine/equilibrator.hpp
@@ -60,13 +60,13 @@ namespace engine
              * Integrator to advance time.  Every `sample_interval` steps, we measure the temperature,
              * keeping a moving average of the last `sample_size` measurements.
              * 
-             * Every `adjustment_interval` steps, we will check to see if the current measured
+             * Every `assessment_interval` steps, we will check to see if the current measured
              * temperature is within `tolerance` of the target temperature.
              * 
              * If this check fails, then we rescale the temperature of the system.  If it succeeds,
              * then we begin a "steady state test" to check whether the value is stable.  This
              * means for an entire `steady_state_time`, the temperature should remain within
-             * the given tolerance; i.e. *every* `adjustment_interval`, the temperature check must
+             * the given tolerance; i.e. *every* `assessment_interval`, the temperature check must
              * succeed, until `steady_state_time` time steps have passed.  If any temperature
              * check fails, then we rescale the temperature and restart the "steady state test".
              * 
@@ -81,7 +81,7 @@ namespace engine
                 double tolerance = 0.05;
                 int sample_size = 20;
                 int sample_interval = 5;
-                int adjustment_interval = 200;
+                int assessment_interval = 200;
                 int steady_state_time = 1000;
                 int timeout = 5000;
 

--- a/src/lennardjonesium/engine/simulation_phase.cpp
+++ b/src/lennardjonesium/engine/simulation_phase.cpp
@@ -1,0 +1,81 @@
+/**
+ * simulation_phase.cpp
+ * 
+ * Copyright (c) 2021-2022 Benjamin E. Niehoff
+ * 
+ * This file is part of Lennard-Jonesium.
+ * 
+ * Lennard-Jonesium is free software: you can redistribute
+ * it and/or modify it under the terms of the GNU General Public
+ * License as published by the Free Software Foundation, either
+ * version 3 of the License, or (at your option) any later version.
+ * 
+ * Lennard-Jonesium is distributed in the hope that it will
+ * be useful, but WITHOUT ANY WARRANTY; without even the implied
+ * warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU General Public License for more details.
+ * 
+ * You should have received a copy of the GNU General Public
+ * License along with Lennard-Jonesium.  If not, see
+ * <https://www.gnu.org/licenses/>.
+ */
+
+#include <variant>
+
+#include <lennardjonesium/tools/math.hpp>
+#include <lennardjonesium/tools/moving_sample.hpp>
+#include <lennardjonesium/physics/measurements.hpp>
+#include <lennardjonesium/engine/simulation_phase.hpp>
+
+namespace engine
+{   
+    CommandVariant
+    EquilibrationPhase::evaluate(int time_step, const physics::Thermodynamics& thermodynamics)
+    {
+        /**
+         * TODO: Could use logging here, in order to see how decisions relate to the measured
+         * temperature.
+         */
+
+        // Collect temperature sample every time step
+        temperatures_.push_back(thermodynamics.temperature());
+
+        bool adjustment_needed = false;
+
+        // Check whether adjustment is needed
+        if (time_step - last_assessment_time_ >= parameters_.assessment_interval) [[unlikely]]
+        {
+            last_assessment_time_ = time_step;
+            last_mean_temperature_ = temperatures_.statistics().mean;
+
+            adjustment_needed = (
+                tools::relative_error(last_mean_temperature_, target_temperature_)
+                >= parameters_.tolerance
+            );
+        }
+
+        // Check whether we are in steady state
+        if ((time_step - last_adjustment_time_ >= parameters_.steady_state_time)
+            && !adjustment_needed) [[unlikely]]
+        {
+            return PhaseComplete{};
+        }
+
+        // Check whether we have reached timeout
+        if (time_step - start_time_ >= parameters_.timeout) [[unlikely]]
+        {
+            return AbortSimulation{};
+        }
+
+        // Send adjustment command if needed
+        if (adjustment_needed) [[unlikely]]
+        {
+            last_adjustment_time_ = time_step;
+            return SetTemperature{target_temperature_};
+        }
+
+        // If none of the above conditions were met, do nothing
+        return std::monostate{};
+    }
+} // namespace engine
+

--- a/src/lennardjonesium/engine/simulation_phase.hpp
+++ b/src/lennardjonesium/engine/simulation_phase.hpp
@@ -1,0 +1,183 @@
+/**
+ * simulation_phase.hpp
+ * 
+ * Copyright (c) 2021-2022 Benjamin E. Niehoff
+ * 
+ * This file is part of Lennard-Jonesium.
+ * 
+ * Lennard-Jonesium is free software: you can redistribute
+ * it and/or modify it under the terms of the GNU General Public
+ * License as published by the Free Software Foundation, either
+ * version 3 of the License, or (at your option) any later version.
+ * 
+ * Lennard-Jonesium is distributed in the hope that it will
+ * be useful, but WITHOUT ANY WARRANTY; without even the implied
+ * warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU General Public License for more details.
+ * 
+ * You should have received a copy of the GNU General Public
+ * License along with Lennard-Jonesium.  If not, see
+ * <https://www.gnu.org/licenses/>.
+ */
+
+#ifndef LJ_SIMULATION_PHASE_HPP
+#define LJ_SIMULATION_PHASE_HPP
+
+#include <vector>
+#include <variant>
+#include <limits>
+
+#include <lennardjonesium/tools/moving_sample.hpp>
+#include <lennardjonesium/physics/measurements.hpp>
+
+namespace engine
+{
+    struct Command
+    {
+        /**
+         * A Command will be issued by a SimulationPhase to inform the Simulation what should
+         * happen next.  The action to be taken can be deduced from the _type_ of the Command,
+         * by using std::variant.  Some commands contain additional information to be used when
+         * executing them.
+         */
+
+        virtual ~Command() = default;
+    };
+
+    // The following commands are all separate derived classes.
+
+    // Record an observation result computed from statistical data
+    struct RecordObservation : Command {};
+
+    // Adjust the temperature of the system
+    struct SetTemperature : Command
+    {
+        double temperature;
+
+        explicit SetTemperature(double temperature) : temperature{temperature} {}
+    };
+
+    // On success, end this phase and move on to next
+    struct PhaseComplete : Command {};
+
+    // On failure, end simulation
+    struct AbortSimulation : Command {};
+
+    // Commands will be issued wrapped in a variant, which can distinguish the type of command.
+    // It is then up to the Simulation to interpret them.
+    using CommandVariant = std::variant<
+        std::monostate,
+        RecordObservation,
+        SetTemperature,
+        PhaseComplete,
+        AbortSimulation
+    >;
+
+    class SimulationPhase
+    {
+        /**
+         * A SimulationPhase drives a particular phase of the simulation (e.g. equilibration or
+         * observation, etc.).  The Simulator provides the SimulationPhase with the data measured
+         * from the SystemState at every time step, and the SimulationPhase makes decisions about
+         * whatever actions to take next (by issuing Commands).  The SimulationPhase can have
+         * internal state (such as further statistical computations).
+         * 
+         * SimulationPhase must be given in its constructor the time step on which it will start
+         * running.  In practice we will use a factory method and dynamic allocation to achieve
+         * this.
+         */
+        public:
+            // Evaluate the thermodynamic properties of the state and issue commands
+            virtual CommandVariant
+            evaluate(int time_step, const physics::Thermodynamics& thermodynamics) = 0;
+
+            virtual ~SimulationPhase() = default;
+        
+        protected:
+            const int start_time_{};
+
+            explicit SimulationPhase(int start_time) : start_time_{start_time} {}
+    };
+
+    class EquilibrationPhase : public SimulationPhase
+    {
+        /**
+         * EquilibrationPhase will attempt to drive the system toward equilibrium at the desired
+         * temperature.  Since temperature is a dependent variable in the microcanonical ensemble,
+         * we cannot actually set a temperature directly; it must be measured instead.  The
+         * InitialCondition attempts to build a state which is close to the desired temperature
+         * by using a Maxwell distribution of velocities.  However, this process is not perfect.
+         * So, the EquilibrationPhase monitors the system for some time, taking
+         * temperature readings, and occasionally rescaling the velocities until the desired
+         * temperature is reached and remains sufficiently stable for some amount of time.
+         */
+
+        public:
+            /**
+             * EquilibrationPhase has a lot of parameters that govern the equilibration process.
+             * These are organized in the Parameters struct.  Their meaning is as follows:
+             * 
+             * tolerance:  The allowed relative error between the system temperature and the
+             *      target temperature.
+             * 
+             * sample_size:  The number of recent temperature measurements to use when estimating
+             *      the system temperature.
+             * 
+             * assessment_interval:  The number of time steps after which to estimate the system
+             *      temperature and make a decision.  If the temperature falls outside the
+             *      tolerance range from the target temperature, then we issue a Command to rescale
+             *      the system temperature.
+             * 
+             * steady_state_time:  If we pass this number of time steps without having to adjust
+             *      the system temperature, then we consider the system to be in equilibrium at the
+             *      target temperature, and we can exit the equilibration phase.
+             * 
+             * timeout:  If we pass this number of time steps without reaching equilibrium, then we
+             *      determine that the system cannot equilibrate and we abort the simulation.
+             */
+            
+            struct Parameters
+            {
+                double tolerance = 0.05;
+                int sample_size = 50;
+                int assessment_interval = 200;
+                int steady_state_time = 1000;
+                int timeout = 5000;
+
+                // We explicitly define a default constructor as demonstrated in this bug report:
+                // https://gcc.gnu.org/bugzilla/show_bug.cgi?id=88165
+                Parameters() {}
+            };
+
+            // The parameters will use the above defaults if not given
+            EquilibrationPhase(
+                int start_time,
+                double target_temperature,
+                Parameters parameters = {}
+            )
+                : SimulationPhase{start_time},
+                  temperatures_(parameters.sample_size),
+                  target_temperature_{target_temperature},
+                  parameters_{parameters},
+                  last_assessment_time_{start_time},
+                  last_adjustment_time_{start_time}
+            {}
+
+            virtual CommandVariant
+            evaluate(int time_step, const physics::Thermodynamics& thermodynamics) override;
+        
+        private:
+            tools::MovingSample<double> temperatures_;
+            const double target_temperature_;
+            const Parameters parameters_;
+            double last_mean_temperature_{std::numeric_limits<double>::signaling_NaN()};
+            int last_assessment_time_;
+            int last_adjustment_time_;
+    };
+
+    class ObservationPhase : public SimulationPhase
+    {};
+} // namespace engine
+
+
+#endif

--- a/tests/lennardjonesium/engine/test_equilibration_phase.cpp
+++ b/tests/lennardjonesium/engine/test_equilibration_phase.cpp
@@ -1,0 +1,150 @@
+/**
+ * Test EquilibrationPhase
+ */
+
+#include <ranges>
+#include <string>
+#include <variant>
+
+#include <catch2/catch.hpp>
+#include <Eigen/Dense>
+
+#include <src/lennardjonesium/physics/system_state.hpp>
+#include <src/lennardjonesium/physics/transformations.hpp>
+#include <src/lennardjonesium/physics/measurements.hpp>
+#include <src/lennardjonesium/engine/simulation_phase.hpp>
+
+SCENARIO("Equilibration Phase decision-making")
+{
+    // Create a state with some velocities
+    physics::SystemState state(50);
+
+    state.positions.setRandom();
+    state.velocities.setRandom();
+
+    // Create thermodynamics object
+    physics::Thermodynamics thermodynamics;
+
+    // Create the equilibration parameters
+    engine::EquilibrationPhase::Parameters parameters{};
+
+    parameters.sample_size = 2;
+    parameters.assessment_interval = 10;
+    parameters.steady_state_time = 100;
+    parameters.timeout = 500;
+
+    int start_time{0};
+    double target_temperature{0.5};
+
+    // Create the EquilibrationPhase object
+    engine::EquilibrationPhase equilibration_phase{
+        start_time,
+        target_temperature,
+        parameters
+    };
+
+    WHEN("I pass a time step that is before the first adjustment interval")
+    {
+        engine::CommandVariant command;
+        state | thermodynamics;
+
+        command = equilibration_phase.evaluate(parameters.assessment_interval - 3, thermodynamics);
+
+        THEN("I get no response")
+        {
+            REQUIRE(std::holds_alternative<std::monostate>(command));
+        }
+    }
+
+    WHEN("I measure an average temperature that is outside the desired range")
+    {
+        engine::CommandVariant command;
+        state | physics::set_temperature(target_temperature * 2) | thermodynamics;
+
+        command = equilibration_phase.evaluate(parameters.assessment_interval - 1, thermodynamics);
+
+        THEN("The command at assessment_interval - 1 should be empty")
+        {
+            REQUIRE(std::holds_alternative<std::monostate>(command));
+        }
+
+        command = equilibration_phase.evaluate(parameters.assessment_interval, thermodynamics);
+
+        THEN("The command at assessment_interval should be to set the temperature")
+        {
+            REQUIRE(std::holds_alternative<engine::SetTemperature>(command));
+            REQUIRE(
+                Approx(target_temperature) == std::get<engine::SetTemperature>(command).temperature
+            );
+        }
+    }
+
+    WHEN("I measure the correct temperature at the adjustment interval")
+    {
+        engine::CommandVariant command;
+        state | physics::set_temperature(target_temperature) | thermodynamics;
+
+        command = equilibration_phase.evaluate(parameters.assessment_interval - 1, thermodynamics);
+
+        THEN("The command at assessment_interval - 1 should be empty")
+        {
+            REQUIRE(std::holds_alternative<std::monostate>(command));
+        }
+
+        command = equilibration_phase.evaluate(parameters.assessment_interval, thermodynamics);
+
+        THEN("The command at assessment_interval should also be empty")
+        {
+            REQUIRE(std::holds_alternative<std::monostate>(command));
+        }
+    }
+
+    WHEN("I measure the correct temperature at the steady state time")
+    {
+        engine::CommandVariant command;
+        state | physics::set_temperature(target_temperature) | thermodynamics;
+
+        // We need to run the "simulation" from the beginning, with fixed temperature
+        for (int time_step : std::views::iota(0, parameters.steady_state_time))
+        {
+            command = equilibration_phase.evaluate(time_step, thermodynamics);
+            REQUIRE(std::holds_alternative<std::monostate>(command));
+        }
+
+        // Now execute the final step
+        command = equilibration_phase.evaluate(parameters.steady_state_time, thermodynamics);
+
+        THEN("The command at steady_state_time should indicate success")
+        {
+            REQUIRE(std::holds_alternative<engine::PhaseComplete>(command));
+        }
+    }
+
+    WHEN("I measure the wrong temperature at timeout")
+    {
+        engine::CommandVariant command;
+
+        state | physics::set_temperature(target_temperature * 2) | thermodynamics;
+
+        // We need to force adjustments to happen over the entire time evolution up until timeout
+        for (int time_step : std::views::iota(0, parameters.timeout))
+        {
+            command = equilibration_phase.evaluate(time_step, thermodynamics);
+
+            if ((time_step > 0) && (time_step % parameters.assessment_interval == 0)) {
+                REQUIRE(std::holds_alternative<engine::SetTemperature>(command));
+            } else {
+                REQUIRE(std::holds_alternative<std::monostate>(command));
+            }
+        }
+
+        // Now execute the final step
+
+        command = equilibration_phase.evaluate(parameters.timeout, thermodynamics);
+
+        THEN("The command at timeout should indicate failure")
+        {
+            REQUIRE(std::holds_alternative<engine::AbortSimulation>(command));
+        }
+    }
+}


### PR DESCRIPTION
Defined the mechanism for implementing "phases" of the simulation while
separating concerns as much as possible.  The simulation will be driven
via a global loop, but a SimulationPhase object will make the actual
decisions about what to do each loop iteration, making use of a Command
pattern.

This way each SimulationPhase doesn't have to drive its own loop, and
there can be a global notion of time.  The Command pattern allows us to
avoid the SimulationPhase having a circular dependency on the Simulation
loop itself.  The cost of this is that the Simulation loop will have to
take responsibility for implementing the Commands that have been
defined.