### PR TITLE
Connect simulation to output buffer

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -112,6 +112,10 @@ add_library(engine STATIC
     src/lennardjonesium/engine/initial_condition.cpp
 )
 
+add_library(output STATIC
+    src/lennardjonesium/output/buffer.hpp
+)
+
 add_library(control STATIC
     src/lennardjonesium/control/command_queue.hpp
     src/lennardjonesium/control/simulation_phase.hpp
@@ -142,12 +146,21 @@ target_link_libraries(engine
     PRIVATE physics
 )
 
+target_link_libraries(output
+    PRIVATE Eigen3::Eigen
+    PRIVATE fmt::fmt
+    PRIVATE tools
+    PRIVATE physics
+    PRIVATE engine
+)
+
 target_link_libraries(control
     PRIVATE Eigen3::Eigen
     PRIVATE fmt::fmt
     PRIVATE tools
     PRIVATE physics
     PRIVATE engine
+    PRIVATE output
 )
 
 if(SKBUILD)
@@ -174,6 +187,7 @@ else()
         PRIVATE tools
         PRIVATE physics
         PRIVATE engine
+        PRIVATE output
         PRIVATE control
     )
 
@@ -214,6 +228,7 @@ else()
         PRIVATE tools
         PRIVATE physics
         PRIVATE engine
+        PRIVATE output
         PRIVATE control
     )
 
@@ -231,6 +246,7 @@ else()
         PRIVATE tools
         PRIVATE physics
         PRIVATE engine
+        PRIVATE output
         PRIVATE control
     )
 

--- a/src/lennardjonesium/output/buffer.hpp
+++ b/src/lennardjonesium/output/buffer.hpp
@@ -1,0 +1,72 @@
+/**
+ * message.hpp
+ * 
+ * Copyright (c) 2021-2022 Benjamin E. Niehoff
+ * 
+ * This file is part of Lennard-Jonesium.
+ * 
+ * Lennard-Jonesium is free software: you can redistribute
+ * it and/or modify it under the terms of the GNU General Public
+ * License as published by the Free Software Foundation, either
+ * version 3 of the License, or (at your option) any later version.
+ * 
+ * Lennard-Jonesium is distributed in the hope that it will
+ * be useful, but WITHOUT ANY WARRANTY; without even the implied
+ * warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU General Public License for more details.
+ * 
+ * You should have received a copy of the GNU General Public
+ * License along with Lennard-Jonesium.  If not, see
+ * <https://www.gnu.org/licenses/>.
+ */
+
+#ifndef LJ_MESSAGE_HPP
+#define LJ_MESSAGE_HPP
+
+#include <string>
+#include <variant>
+
+#include <lennardjonesium/physics/measurements.hpp>
+#include <lennardjonesium/physics/observation.hpp>
+#include <lennardjonesium/tools/message_buffer.hpp>
+
+namespace output
+{
+    /**
+     * We define the format we expect to use for Messages which will be logged to various files.
+     * They will be combined into a std::variant so that we can switch on the type of message.
+     * 
+     * Note: We could have used std::pair<int, T> for each of these, but then it wouldn't be so
+     * clear that the int is intended to be the time step.
+     */
+
+    struct EventMessage
+    {
+        int time_step;
+        std::string description;
+    };
+
+    struct ObservationMessage
+    {
+        int time_step;
+        physics::Observation observation;
+    };
+
+    struct ThermodynamicMessage
+    {
+        int time_step;
+        physics::ThermodynamicMeasurement::Result result;
+    };
+
+    using Message = std::variant<
+        EventMessage,
+        ObservationMessage,
+        ThermodynamicMessage
+    >;
+
+    // The Buffer class itself is just a type alias
+    using Buffer = tools::MessageBuffer<Message>;
+} // namespace output
+
+
+#endif

--- a/tests/integration/test_system_equilibration.cpp
+++ b/tests/integration/test_system_equilibration.cpp
@@ -21,6 +21,7 @@
 #include <src/lennardjonesium/engine/boundary_condition.hpp>
 #include <src/lennardjonesium/engine/initial_condition.hpp>
 #include <src/lennardjonesium/engine/integrator.hpp>
+#include <src/lennardjonesium/output/buffer.hpp>
 #include <src/lennardjonesium/control/simulation_phase.hpp>
 #include <src/lennardjonesium/control/simulation.hpp>
 
@@ -106,7 +107,9 @@ SCENARIO("Equilibrating the system")
             )
         );
 
-        control::Simulation simulation(integrator, std::move(schedule));
+        auto output_buffer = std::make_shared<output::Buffer>();
+
+        control::Simulation simulation(integrator, std::move(schedule), output_buffer);
 
         THEN("The system equilibrates to the desired temperature")
         {
@@ -143,7 +146,9 @@ SCENARIO("Equilibrating the system")
             )
         );
 
-        control::Simulation simulation(integrator, std::move(schedule));
+        auto output_buffer = std::make_shared<output::Buffer>();
+
+        control::Simulation simulation(integrator, std::move(schedule), output_buffer);
 
         THEN("The system fails to equilibrate")
         {


### PR DESCRIPTION
Have now added the synchronized MessageBuffer to the Simulation class,
giving it the ability to log events and measurements/observations.

However, there is not yet set up any consumer to take these messages
and do anything with them.