### PR TITLE
Create temp directory when building tests

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -265,6 +265,11 @@ else()
     )
 
     include(Catch)
-    catch_discover_tests(unit_tests WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}/temp)
-    # catch_discover_tests(integration_tests WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}/temp)
+
+    # Make sure the temp directory exists (otherwise catch_discover_tests fails!)
+    set(lj_temp_dir ${PROJECT_SOURCE_DIR}/temp)
+    file(MAKE_DIRECTORY ${lj_temp_dir})
+
+    catch_discover_tests(unit_tests WORKING_DIRECTORY ${lj_temp_dir})
+    # catch_discover_tests(integration_tests WORKING_DIRECTORY ${lj_temp_dir})
 endif()


### PR DESCRIPTION
Cloned the repository on a new machine and had trouble running the
tests.  Eventually figured out that the WORKING_DIRECTORY for various
CMake commands must already exist.  So, add a CMake command to create
this directory if it doesn't exist.