### PR TITLE
Close files before reading them back in

### DIFF
--- a/tests/lennardjonesium/output/test_logger.cpp
+++ b/tests/lennardjonesium/output/test_logger.cpp
@@ -69,6 +69,11 @@ SCENARIO("Logger sends to correct files")
 
         // Close the logger
         logger.close();
+
+        // Close the files
+        event_log.close();
+        thermodynamic_log.close();
+        observation_log.close();
         
         WHEN("I read the events log back in")
         {


### PR DESCRIPTION
For some reason, this didn't cause a problem in WSL Ubuntu on Windows,
but on bare-metal Ubuntu, the behavior is different.  The files must be
closed before reopening them to read them in.  I'm guessing that Windows
is somehow more permissive about how files are opened, or maybe GCC 11.2
under WSL is automatically closing the files when they are reopened in
a different mode, but GCC 11.2 in bare-metal Linux is not.