### PR TITLE
Remove mutable default argument

### DIFF
--- a/src/python/lennardjonesium/simulation/_simulation.pyx
+++ b/src/python/lennardjonesium/simulation/_simulation.pyx
@@ -36,7 +36,10 @@ cdef class Simulation:
     """
     cdef unique_ptr[_Simulation] _simulation
 
-    def __cinit__(self, configuration = Configuration()):
+    def __cinit__(self, configuration = None):
+        if configuration is None:
+            configuration = Configuration()
+
         if (not isinstance(configuration, Configuration)):
             raise TypeError('Initialization argument must be of type Configuration')
         


### PR DESCRIPTION
__cinit__() was previously taking a Configuration() default argument,
but Configuration is a mutable dataclass.  Changed the argument to
None.