### PR TITLE
Add orchestration submodule and run() function

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -16,7 +16,11 @@ setup(
     description="A simulator for the Lennard-Jones substance",
     author='Ben Niehoff',
     license="GPL v3.0",
-    packages=['lennardjonesium', 'lennardjonesium.simulation'],
+    packages=[
+        'lennardjonesium',
+        'lennardjonesium.simulation',
+        'lennardjonesium.orchestration',
+        ],
     package_dir = {
         '': 'src/python',
         },

--- a/src/python/lennardjonesium/__init__.py
+++ b/src/python/lennardjonesium/__init__.py
@@ -1,3 +1,5 @@
+from lennardjonesium.orchestration import run
+
 from lennardjonesium.simulation import SeedGenerator
 from lennardjonesium.simulation import Configuration
 from lennardjonesium.simulation import Simulation

--- a/src/python/lennardjonesium/orchestration/__init__.py
+++ b/src/python/lennardjonesium/orchestration/__init__.py
@@ -1,0 +1,1 @@
+from lennardjonesium.orchestration.run import run

--- a/src/python/lennardjonesium/orchestration/run.py
+++ b/src/python/lennardjonesium/orchestration/run.py
@@ -1,0 +1,92 @@
+"""
+run.py
+
+Copyright (c) 2021-2022 Benjamin E. Niehoff
+
+This file is part of Lennard-Jonesium.
+
+Lennard-Jonesium is free software: you can redistribute
+it and/or modify it under the terms of the GNU General Public
+License as published by the Free Software Foundation, either
+version 3 of the License, or (at your option) any later version.
+
+Lennard-Jonesium is distributed in the hope that it will
+be useful, but WITHOUT ANY WARRANTY; without even the implied
+warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+See the GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public
+License along with Lennard-Jonesium.  If not, see
+<https://www.gnu.org/licenses/>.
+"""
+
+
+import os
+import pathlib
+from typing import Union, Optional
+from types import FunctionType, BuiltinFunctionType
+from copy import deepcopy
+
+from lennardjonesium.simulation import Configuration, Simulation, SeedGenerator
+
+def run(
+    config_file: Union[str, pathlib.Path],
+    echo_status: bool = True,
+    random_seed: Union[None, int, FunctionType, BuiltinFunctionType] = None,
+    config_object: Optional[Configuration] = None
+):
+    """
+    Wrapper function for running a single simulation.
+
+    :param config_file: File path to the config file which describes the simulation to be run.
+        The output config file will be written to the same place (possibly after changing the
+        random seed).  If this file does not already exist, then the config_object parameter MUST
+        be given, and a config file will be created at this path.  If the config file does exist,
+        it will be overwritten, perhaps with a fresh random seed.
+    
+    :param random_seed: Can be None, an int, or a function which takes 0 arguments.
+        If None, then use the random seed from the config file.
+        If an int, then use this random seed.
+        If a function, then call this function to obtain a random seed.
+    
+    :param config_object: An optional Configuration object.  If this is given, then it will be used
+        in preference over the config_file, and the config_file will be overwritten with the data
+        provided by the config_object.  If a new random seed has been provided, then it will
+        override the one given in the config_object.
+    
+    We will always output a config file with the random seed actually used, which will overwrite
+    the original config file.
+
+    TODO: Add some preamble that pretty-prints the Configuration data before the run, and
+        congratulates the user when the run is finished.
+    """
+
+    config_filepath = pathlib.Path(config_file).resolve()
+
+    if not config_filepath.is_file() and config_object is None:
+        raise ValueError('config_object must be given if config_file is not an existing file')
+    
+    if config_object is None:
+        cfg = Configuration.from_file(config_filepath)
+    else:
+        cfg = deepcopy(config_object)
+    
+    if isinstance(random_seed, int):
+        cfg.system.random_seed = random_seed
+    elif isinstance(random_seed, (FunctionType, BuiltinFunctionType)):
+        cfg.system.random_seed = random_seed()
+    
+    # Write (or overwrite) the config file with the new random seed
+    config_filepath.parent.mkdir(parents=True, exist_ok=True)
+    cfg.write(config_filepath)
+    
+    # Change working directory to the directory where the config file is located
+    cwd = os.getcwd()
+    os.chdir(config_filepath.parent)
+
+    # Create the Simulation object and run the simulation
+    sim = Simulation(cfg)
+    sim.run(echo=echo_status)
+
+    # Restore the working directory
+    os.chdir(cwd)

--- a/src/python/lennardjonesium/simulation/configuration.py
+++ b/src/python/lennardjonesium/simulation/configuration.py
@@ -139,7 +139,14 @@ class Configuration:
 
     def read(self, filename: str):
         """
-        Reads a Configuration from a file
+        Reads a Configuration from a file.
+
+        The filepaths for the log files will be read literally from the config file, whether they
+        are absolute or relative paths.  This works fine if one is running LennardJonesium from the
+        same directory where the config file is located.  In other cases, one probably wants a
+        relative path to be interpreted as relative to the location of the config file, rather than
+        from the working directory where Python was launched.  This circumstance will be handled
+        elsewhere.
         """
         parser = configparser.ConfigParser()
         parser.read(filename)


### PR DESCRIPTION
Added a simple run() function which takes care of all the details of
loading a config file, choosing a new random seed, writing the updated
config file, and running the simulation.